### PR TITLE
Add Python 3.12 to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         platform: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
As per the [Status of Python versions](https://devguide.python.org/versions/).