### PR TITLE
Stop using `setuptools-scm`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "chws_tool"
-# version = "1.4.3"
-dynamic = ["version"]
+version = "1.4.4"
 description = "Utility for OpenType chws/vchw features"
 authors = [
     { name = "Koji Ishii", email = "kojii@chromium.org" }
@@ -32,14 +31,11 @@ dev = [
 add-chws = 'chws_tool.add_chws:main'
 
 [build-system]
-requires = ["setuptools >= 77.0.3", "setuptools-scm>=8"]
+requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 testpaths = "tests"
-
-[tool.setuptools_scm]
-version_file = "src/chws_tool/_version.py"
 
 [tool.uv]
 # https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata

--- a/src/chws_tool/__init__.py
+++ b/src/chws_tool/__init__.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from ._version import version as __version__  # type: ignore
-except ImportError:
-    __version__ = "0.0.0+unknown"
-
 from .config import GoogleFontsConfig
 from .add_chws import add_chws
 from .add_chws import add_chws_async

--- a/src/chws_tool/add_chws.py
+++ b/src/chws_tool/add_chws.py
@@ -24,7 +24,6 @@ from typing import Optional
 from typing import Union
 
 import east_asian_spacing as chws
-from chws_tool import __version__
 from chws_tool.config import GoogleFontsConfig
 
 logger = logging.getLogger("add_chws")
@@ -120,12 +119,6 @@ async def main_async() -> None:
     )
     parser.add_argument(
         "-v", "--verbose", help="increase output verbosity", action="count", default=0
-    )
-    parser.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version=f"%(prog)s {__version__} (east-asian-spacing {chws.__version__})",
     )
     args = parser.parse_args()
     chws.init_logging(args.verbose, main=logger)


### PR DESCRIPTION
Because dependabot fails.

See https://github.com/kojiishi/east_asian_spacing/issues/298.
