### PR TITLE
Change the build system to `hatchling`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dev = [
 add-chws = 'chws_tool.add_chws:main'
 
 [build-system]
-requires = ["setuptools >= 77.0.3"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 testpaths = "tests"


### PR DESCRIPTION
This is a speculative fix for the dependabot errors, reporting `Expected lockfile to change!`.

The `hatchling` is a recommended [uv build backend].

[uv build backend]: https://docs.astral.sh/uv/concepts/build-backend/
