### PR TITLE
ci: Run without `tox`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Dependencies
       run: uv sync
     - name: Run style and typing checks
-      run: uv run tox -e lint
+      run: uv run black --check --diff src tests
   test:
     runs-on: ${{ matrix.platform }}
     strategy:
@@ -35,7 +35,7 @@ jobs:
     - name: Install Dependencies
       run: uv sync
     - name: Run the tests
-      run: uv run tox -e py
+      run: uv run pytest
   deploy:
     # only run if the commit is tagged...
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
`tox` fails for some reasons; e.g.:
https://github.com/googlefonts/chws_tool/actions/runs/23678541481/job/68986369198?pr=305
